### PR TITLE
Add tiered stats to request cache response 

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/indices/IndicesRequestCacheDiskTierIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/IndicesRequestCacheDiskTierIT.java
@@ -1,0 +1,88 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.indices;
+
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.client.Client;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.core.common.unit.ByteSizeValue;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.test.OpenSearchIntegTestCase;
+
+import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertAcked;
+import static org.opensearch.test.hamcrest.OpenSearchAssertions.assertSearchResponse;
+
+// This is a separate file from IndicesRequestCacheIT because we only want to run our test
+// on a node with a maximum request cache size that we set.
+
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 0)
+public class IndicesRequestCacheDiskTierIT extends OpenSearchIntegTestCase {
+    public void testDiskTierStats() throws Exception {
+        int heapSizeBytes = 1800; // enough to fit 2 queries, as each is 687 B
+        int requestSize = 687; // each request is 687 B
+        String node = internalCluster().startNode(
+            Settings.builder().put(IndicesRequestCache.INDICES_CACHE_QUERY_SIZE.getKey(), new ByteSizeValue(heapSizeBytes))
+        );
+        Client client = client(node);
+
+        Settings.Builder indicesSettingBuilder = Settings.builder()
+            .put(IndicesRequestCache.INDEX_CACHE_REQUEST_ENABLED_SETTING.getKey(), true)
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0);
+
+        assertAcked(
+            client.admin().indices().prepareCreate("index").setMapping("k", "type=keyword").setSettings(indicesSettingBuilder).get()
+        );
+        indexRandom(true, client.prepareIndex("index").setSource("k", "hello"));
+        ensureSearchable("index");
+        SearchResponse resp;
+
+        int numOnDisk = 5;
+        int numRequests = heapSizeBytes / requestSize + numOnDisk;
+        for (int i = 0; i < numRequests; i++) {
+            resp = client.prepareSearch("index").setRequestCache(true).setQuery(QueryBuilders.termQuery("k", "hello" + i)).get();
+            assertSearchResponse(resp);
+            IndicesRequestCacheIT.assertCacheState(client, "index", 0, i + 1, TierType.ON_HEAP, false);
+            IndicesRequestCacheIT.assertCacheState(client, "index", 0, i + 1, TierType.DISK, false);
+            System.out.println("request number " + i);
+        }
+
+        System.out.println("Num requests = " + numRequests);
+
+        // the first request, for "hello0", should have been evicted to the disk tier
+        resp = client.prepareSearch("index").setRequestCache(true).setQuery(QueryBuilders.termQuery("k", "hello0")).get();
+        IndicesRequestCacheIT.assertCacheState(client, "index", 0, numRequests + 1, TierType.ON_HEAP, false);
+        IndicesRequestCacheIT.assertCacheState(client, "index", 1, numRequests, TierType.DISK, false);
+    }
+}

--- a/server/src/internalClusterTest/java/org/opensearch/indices/IndicesRequestCacheIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/IndicesRequestCacheIT.java
@@ -43,7 +43,6 @@ import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.time.DateFormatter;
 import org.opensearch.common.util.FeatureFlags;
-import org.opensearch.core.common.unit.ByteSizeValue;
 import org.opensearch.index.cache.request.RequestCacheStats;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.search.aggregations.bucket.global.GlobalAggregationBuilder;

--- a/server/src/internalClusterTest/java/org/opensearch/indices/IndicesRequestCacheIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/IndicesRequestCacheIT.java
@@ -637,13 +637,19 @@ public class IndicesRequestCacheIT extends ParameterizedOpenSearchIntegTestCase 
 
     public void testCacheWithInvalidation() throws Exception {
         Client client = client();
-
-        Settings.Builder builder = Settings.builder()
-            .put(IndicesRequestCache.INDEX_CACHE_REQUEST_ENABLED_SETTING.getKey(), true)
-            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
-            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0);
-
-        assertAcked(client.admin().indices().prepareCreate("index").setMapping("k", "type=keyword").setSettings(builder).get());
+        assertAcked(
+            client.admin()
+                .indices()
+                .prepareCreate("index")
+                .setMapping("k", "type=keyword")
+                .setSettings(
+                    Settings.builder()
+                        .put(IndicesRequestCache.INDEX_CACHE_REQUEST_ENABLED_SETTING.getKey(), true)
+                        .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+                        .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+                )
+                .get()
+        );
         indexRandom(true, client.prepareIndex("index").setSource("k", "hello"));
         ensureSearchable("index");
         SearchResponse resp = client.prepareSearch("index").setRequestCache(true).setQuery(QueryBuilders.termQuery("k", "hello")).get();

--- a/server/src/internalClusterTest/java/org/opensearch/indices/IndicesRequestCacheIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/IndicesRequestCacheIT.java
@@ -34,6 +34,7 @@ package org.opensearch.indices;
 
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
+import org.opensearch.action.IndicesRequestIT;
 import org.opensearch.action.admin.indices.alias.Alias;
 import org.opensearch.action.admin.indices.forcemerge.ForceMergeResponse;
 import org.opensearch.action.search.SearchResponse;
@@ -43,6 +44,7 @@ import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.time.DateFormatter;
 import org.opensearch.common.util.FeatureFlags;
+import org.opensearch.core.common.unit.ByteSizeValue;
 import org.opensearch.index.cache.request.RequestCacheStats;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.search.aggregations.bucket.global.GlobalAggregationBuilder;
@@ -636,16 +638,27 @@ public class IndicesRequestCacheIT extends ParameterizedOpenSearchIntegTestCase 
 
     public void testCacheWithInvalidation() throws Exception {
         Client client = client();
+        //int heapSizeBytes = 2000; // enough to fit 2 queries, as each is 687 B
+
+        Settings.Builder builder = Settings.builder()
+            .put(IndicesRequestCache.INDEX_CACHE_REQUEST_ENABLED_SETTING.getKey(), true)
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+            .put(IndicesRequestCache.INDICES_CACHE_QUERY_SIZE.getKey(), new ByteSizeValue(2000));
+        // Why is it appending "index." to the beginning of the key??
+
+        String heapSizeBytes = builder.get(IndicesRequestCache.INDICES_CACHE_QUERY_SIZE.getKey());
+        System.out.println("Current cap = " + heapSizeBytes);
+
+        client.admin().setSettings(Settings.builder().put(IndicesRequestCache.INDICES_CACHE_QUERY_SIZE.getKey(), new ByteSizeValue(2000)));
+
         assertAcked(
             client.admin()
                 .indices()
                 .prepareCreate("index")
                 .setMapping("k", "type=keyword")
                 .setSettings(
-                    Settings.builder()
-                        .put(IndicesRequestCache.INDEX_CACHE_REQUEST_ENABLED_SETTING.getKey(), true)
-                        .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
-                        .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+                    builder
                 )
                 .get()
         );
@@ -662,8 +675,9 @@ public class IndicesRequestCacheIT extends ParameterizedOpenSearchIntegTestCase 
         resp = client.prepareSearch("index").setRequestCache(true).setQuery(QueryBuilders.termQuery("k", "hello")).get();
         assertSearchResponse(resp);
         // Should expect hit as here as refresh didn't happen
-        assertCacheState(client, "index", 1, 1);
-        assertNumCacheEntries(client, "index", 1);
+        assertCacheState(client, "index", 1, 1, TierType.ON_HEAP);
+        assertCacheState(client, "index", 0, 1, TierType.DISK);
+        assertNumCacheEntries(client, "index", 1, TierType.ON_HEAP);
 
         // Explicit refresh would invalidate cache
         refresh();
@@ -671,12 +685,13 @@ public class IndicesRequestCacheIT extends ParameterizedOpenSearchIntegTestCase 
         resp = client.prepareSearch("index").setRequestCache(true).setQuery(QueryBuilders.termQuery("k", "hello")).get();
         assertSearchResponse(resp);
         // Should expect miss as key has changed due to change in IndexReader.CacheKey (due to refresh)
-        assertCacheState(client, "index", 1, 2);
-        assertNumCacheEntries(client, "index", 1); // Shouldn't it just be the most recent query, since the first one was invalidated? (prob invalidation isnt in yet)
+        assertCacheState(client, "index", 1, 2, TierType.ON_HEAP);
+        assertCacheState(client, "index", 0, 2, TierType.DISK);
+        assertNumCacheEntries(client, "index", 1, TierType.ON_HEAP); // Shouldn't it just be the most recent query, since the first one was invalidated? (prob invalidation isnt in yet)
         // yeah - evictions = 0, its not in yet
     }
 
-    private static void assertCacheState(Client client, String index, long expectedHits, long expectedMisses) {
+    private static void assertCacheState(Client client, String index, long expectedHits, long expectedMisses, TierType tierType) {
         RequestCacheStats requestCacheStats = client.admin()
             .indices()
             .prepareStats(index)
@@ -686,14 +701,18 @@ public class IndicesRequestCacheIT extends ParameterizedOpenSearchIntegTestCase 
             .getRequestCache();
         // Check the hit count and miss count together so if they are not
         // correct we can see both values
+        System.out.println("mem size " + requestCacheStats.getMemorySize(tierType));
         assertEquals(
             Arrays.asList(expectedHits, expectedMisses, 0L),
-            Arrays.asList(requestCacheStats.getHitCount(), requestCacheStats.getMissCount(), requestCacheStats.getEvictions())
+            Arrays.asList(requestCacheStats.getHitCount(tierType), requestCacheStats.getMissCount(tierType), requestCacheStats.getEvictions(tierType))
         );
-
     }
 
-    private static void assertNumCacheEntries(Client client, String index, long expectedEntries) {
+    private static void assertCacheState(Client client, String index, long expectedHits, long expectedMisses) {
+        assertCacheState(client, index, expectedHits, expectedMisses, TierType.ON_HEAP);
+    }
+
+    private static void assertNumCacheEntries(Client client, String index, long expectedEntries, TierType tierType) {
         RequestCacheStats requestCacheStats = client.admin()
             .indices()
             .prepareStats(index)
@@ -701,7 +720,7 @@ public class IndicesRequestCacheIT extends ParameterizedOpenSearchIntegTestCase 
             .get()
             .getTotal()
             .getRequestCache();
-        assertEquals(expectedEntries, requestCacheStats.getEntries());
+        assertEquals(expectedEntries, requestCacheStats.getEntries(tierType));
     }
 
 }

--- a/server/src/internalClusterTest/java/org/opensearch/indices/IndicesRequestCacheIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/IndicesRequestCacheIT.java
@@ -691,10 +691,6 @@ public class IndicesRequestCacheIT extends ParameterizedOpenSearchIntegTestCase 
             .getRequestCache();
         // Check the hit count and miss count together so if they are not
         // correct we can see both values
-        ByteSizeValue memSize = requestCacheStats.getMemorySize(tierType);
-        if (memSize.getBytes() > 0) {
-            System.out.println("mem size " + memSize);
-        }
         if (enforceZeroEvictions) {
             assertEquals(
                 Arrays.asList(expectedHits, expectedMisses, 0L),

--- a/server/src/main/java/org/opensearch/common/metrics/CounterMetric.java
+++ b/server/src/main/java/org/opensearch/common/metrics/CounterMetric.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.common.metrics;
 
-import java.io.Serializable;
 import java.util.concurrent.atomic.LongAdder;
 
 /**

--- a/server/src/main/java/org/opensearch/index/cache/request/RequestCacheStats.java
+++ b/server/src/main/java/org/opensearch/index/cache/request/RequestCacheStats.java
@@ -52,18 +52,17 @@ import java.util.Map;
  */
 public class RequestCacheStats implements Writeable, ToXContentFragment {
 
-    private Map<String, StatsHolder> map;
-
-    public RequestCacheStats() {
-        this.map = new HashMap<>();
-        for (TierType tierType : TierType.values()) {
-            map.put(tierType.getStringValue(), new StatsHolder());
+    private Map<String, StatsHolder> map = new HashMap<>(){{
+        for (TierType tierType : TierType.values())
+        {
+            put(tierType.getStringValue(), new StatsHolder());
             // Every possible tier type must have counters, even if they are disabled. Then the counters report 0
-        }
-    }
+        }}
+    };
+
+    public RequestCacheStats() {}
 
     public RequestCacheStats(StreamInput in) throws IOException {
-        this();
         if (in.getVersion().onOrAfter(Version.V_3_0_0)) {
             this.map = in.readMap(StreamInput::readString, StatsHolder::new);
         } else {
@@ -78,7 +77,6 @@ public class RequestCacheStats implements Writeable, ToXContentFragment {
 
     public RequestCacheStats(Map<TierType, StatsHolder> inputMap) {
         // Create a RequestCacheStats with multiple tiers' statistics
-        this();
         for (TierType tierType : inputMap.keySet()) {
             map.put(tierType.getStringValue(), inputMap.get(tierType));
         }

--- a/server/src/main/java/org/opensearch/index/cache/request/RequestCacheStats.java
+++ b/server/src/main/java/org/opensearch/index/cache/request/RequestCacheStats.java
@@ -53,6 +53,7 @@ import java.util.Map;
 public class RequestCacheStats implements Writeable, ToXContentFragment {
 
     private Map<String, StatsHolder> map;
+
     public RequestCacheStats() {
         this.map = new HashMap<>();
         for (TierType tierType : TierType.values()) {
@@ -64,22 +65,15 @@ public class RequestCacheStats implements Writeable, ToXContentFragment {
     public RequestCacheStats(StreamInput in) throws IOException {
         this();
         if (in.getVersion().onOrAfter(Version.V_3_0_0)) {
-            this.map = in.readMap(StreamInput::readString, StatsHolder::new); // does it know to use the right constructor? does it rly need to be registered?
+            this.map = in.readMap(StreamInput::readString, StatsHolder::new); // does it know to use the right constructor? does it rly need
+                                                                              // to be registered?
         } else {
             // objects from earlier versions only contain on-heap info, and do not have entries info
             long memorySize = in.readVLong();
             long evictions = in.readVLong();
             long hitCount = in.readVLong();
             long missCount = in.readVLong();
-            this.map.put(
-                TierType.ON_HEAP.getStringValue(),
-                new StatsHolder(
-                    memorySize,
-                    evictions,
-                    hitCount,
-                    missCount,
-                    0
-                ));
+            this.map.put(TierType.ON_HEAP.getStringValue(), new StatsHolder(memorySize, evictions, hitCount, missCount, 0));
         }
     }
 

--- a/server/src/main/java/org/opensearch/index/cache/request/RequestCacheStats.java
+++ b/server/src/main/java/org/opensearch/index/cache/request/RequestCacheStats.java
@@ -52,6 +52,7 @@ public class RequestCacheStats implements Writeable, ToXContentFragment {
     private long evictions;
     private long hitCount;
     private long missCount;
+    private long entries; // number of entries in the cache
 
     public RequestCacheStats() {}
 
@@ -60,13 +61,15 @@ public class RequestCacheStats implements Writeable, ToXContentFragment {
         evictions = in.readVLong();
         hitCount = in.readVLong();
         missCount = in.readVLong();
+        entries = in.readVLong();
     }
 
-    public RequestCacheStats(long memorySize, long evictions, long hitCount, long missCount) {
+    public RequestCacheStats(long memorySize, long evictions, long hitCount, long missCount, long entries) { //
         this.memorySize = memorySize;
         this.evictions = evictions;
         this.hitCount = hitCount;
         this.missCount = missCount;
+        this.entries = entries;
     }
 
     public void add(RequestCacheStats stats) {
@@ -74,6 +77,7 @@ public class RequestCacheStats implements Writeable, ToXContentFragment {
         this.evictions += stats.evictions;
         this.hitCount += stats.hitCount;
         this.missCount += stats.missCount;
+        this.entries += stats.entries;
     }
 
     public long getMemorySizeInBytes() {
@@ -96,12 +100,17 @@ public class RequestCacheStats implements Writeable, ToXContentFragment {
         return this.missCount;
     }
 
+    public long getEntries() {
+        return this.entries;
+    }
+
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeVLong(memorySize);
         out.writeVLong(evictions);
         out.writeVLong(hitCount);
         out.writeVLong(missCount);
+        out.writeVLong(entries);
     }
 
     @Override
@@ -111,6 +120,7 @@ public class RequestCacheStats implements Writeable, ToXContentFragment {
         builder.field(Fields.EVICTIONS, getEvictions());
         builder.field(Fields.HIT_COUNT, getHitCount());
         builder.field(Fields.MISS_COUNT, getMissCount());
+        builder.field(Fields.ENTRIES, getEntries());
         builder.endObject();
         return builder;
     }
@@ -127,5 +137,6 @@ public class RequestCacheStats implements Writeable, ToXContentFragment {
         static final String EVICTIONS = "evictions";
         static final String HIT_COUNT = "hit_count";
         static final String MISS_COUNT = "miss_count";
+        static final String ENTRIES = "entries";
     }
 }

--- a/server/src/main/java/org/opensearch/index/cache/request/RequestCacheStats.java
+++ b/server/src/main/java/org/opensearch/index/cache/request/RequestCacheStats.java
@@ -65,8 +65,7 @@ public class RequestCacheStats implements Writeable, ToXContentFragment {
     public RequestCacheStats(StreamInput in) throws IOException {
         this();
         if (in.getVersion().onOrAfter(Version.V_3_0_0)) {
-            this.map = in.readMap(StreamInput::readString, StatsHolder::new); // does it know to use the right constructor? does it rly need
-                                                                              // to be registered?
+            this.map = in.readMap(StreamInput::readString, StatsHolder::new);
         } else {
             // objects from earlier versions only contain on-heap info, and do not have entries info
             long memorySize = in.readVLong();
@@ -84,8 +83,6 @@ public class RequestCacheStats implements Writeable, ToXContentFragment {
             map.put(tierType.getStringValue(), inputMap.get(tierType));
         }
     }
-
-    // can prob eliminate some of these constructors
 
     public void add(RequestCacheStats stats) {
         for (String tier : stats.map.keySet()) {

--- a/server/src/main/java/org/opensearch/index/cache/request/ShardRequestCache.java
+++ b/server/src/main/java/org/opensearch/index/cache/request/ShardRequestCache.java
@@ -33,11 +33,9 @@
 package org.opensearch.index.cache.request;
 
 import org.apache.lucene.util.Accountable;
-import org.opensearch.common.metrics.CounterMetric;
 import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.indices.TierType;
 
-import java.io.Serializable;
 import java.util.EnumMap;
 
 /**
@@ -57,40 +55,11 @@ public final class ShardRequestCache {
 
     public RequestCacheStats stats() {
         // TODO: Change RequestCacheStats to support disk tier stats.
-        return stats(TierType.ON_HEAP);
+        // Changing this function to return a RequestCacheStats with stats from all tiers.
+        //return stats(TierType.ON_HEAP);
+        return new RequestCacheStats(statsHolder);
     }
 
-    public RequestCacheStats stats(TierType tierType) {
-        return new RequestCacheStats(
-            statsHolder.get(tierType).totalMetric.count(),
-            statsHolder.get(tierType).evictionsMetric.count(),
-            statsHolder.get(tierType).hitCount.count(),
-            statsHolder.get(tierType).missCount.count(),
-            statsHolder.get(tierType).entries.count()
-        );
-    }
-
-    public RequestCacheStats overallStats() {
-        long totalSize = 0;
-        long totalEvictions = 0;
-        long totalHits = 0;
-        long totalMisses = 0;
-        long totalEntries = 0;
-        for (TierType tierType : TierType.values()) {
-            totalSize += statsHolder.get(tierType).totalMetric.count();
-            totalEvictions += statsHolder.get(tierType).evictionsMetric.count();
-            totalHits += statsHolder.get(tierType).hitCount.count();
-            totalMisses += statsHolder.get(tierType).missCount.count();
-            totalEntries += statsHolder.get(tierType).entries.count();
-        }
-        return new RequestCacheStats(
-            totalSize,
-            totalEvictions,
-            totalHits,
-            totalMisses,
-            totalEntries
-        );
-    }
 
     public void onHit(TierType tierType) {
         statsHolder.get(tierType).hitCount.inc();
@@ -118,14 +87,5 @@ public final class ShardRequestCache {
         }
         statsHolder.get(tierType).totalMetric.dec(dec);
         statsHolder.get(tierType).entries.dec();
-    }
-
-    static class StatsHolder implements Serializable {
-
-        final CounterMetric evictionsMetric = new CounterMetric();
-        final CounterMetric totalMetric = new CounterMetric();
-        final CounterMetric hitCount = new CounterMetric();
-        final CounterMetric missCount = new CounterMetric();
-        final CounterMetric entries = new CounterMetric();
     }
 }

--- a/server/src/main/java/org/opensearch/index/cache/request/ShardRequestCache.java
+++ b/server/src/main/java/org/opensearch/index/cache/request/ShardRequestCache.java
@@ -65,7 +65,8 @@ public final class ShardRequestCache {
             statsHolder.get(tierType).totalMetric.count(),
             statsHolder.get(tierType).evictionsMetric.count(),
             statsHolder.get(tierType).hitCount.count(),
-            statsHolder.get(tierType).missCount.count()
+            statsHolder.get(tierType).missCount.count(),
+            statsHolder.get(tierType).entries.count()
         );
     }
 
@@ -74,17 +75,20 @@ public final class ShardRequestCache {
         long totalEvictions = 0;
         long totalHits = 0;
         long totalMisses = 0;
+        long totalEntries = 0;
         for (TierType tierType : TierType.values()) {
             totalSize += statsHolder.get(tierType).totalMetric.count();
             totalEvictions += statsHolder.get(tierType).evictionsMetric.count();
             totalHits += statsHolder.get(tierType).hitCount.count();
             totalMisses += statsHolder.get(tierType).missCount.count();
+            totalEntries += statsHolder.get(tierType).entries.count();
         }
         return new RequestCacheStats(
             totalSize,
             totalEvictions,
             totalHits,
-            totalMisses
+            totalMisses,
+            totalEntries
         );
     }
 
@@ -98,6 +102,7 @@ public final class ShardRequestCache {
 
     public void onCached(Accountable key, BytesReference value, TierType tierType) {
         statsHolder.get(tierType).totalMetric.inc(key.ramBytesUsed() + value.ramBytesUsed());
+        statsHolder.get(tierType).entries.inc();
     }
 
     public void onRemoval(Accountable key, BytesReference value, boolean evicted, TierType tierType) {
@@ -112,6 +117,7 @@ public final class ShardRequestCache {
             dec += value.ramBytesUsed();
         }
         statsHolder.get(tierType).totalMetric.dec(dec);
+        statsHolder.get(tierType).entries.dec();
     }
 
     static class StatsHolder implements Serializable {
@@ -120,5 +126,6 @@ public final class ShardRequestCache {
         final CounterMetric totalMetric = new CounterMetric();
         final CounterMetric hitCount = new CounterMetric();
         final CounterMetric missCount = new CounterMetric();
+        final CounterMetric entries = new CounterMetric();
     }
 }

--- a/server/src/main/java/org/opensearch/index/cache/request/ShardRequestCache.java
+++ b/server/src/main/java/org/opensearch/index/cache/request/ShardRequestCache.java
@@ -56,10 +56,9 @@ public final class ShardRequestCache {
     public RequestCacheStats stats() {
         // TODO: Change RequestCacheStats to support disk tier stats.
         // Changing this function to return a RequestCacheStats with stats from all tiers.
-        //return stats(TierType.ON_HEAP);
+        // return stats(TierType.ON_HEAP);
         return new RequestCacheStats(statsHolder);
     }
-
 
     public void onHit(TierType tierType) {
         statsHolder.get(tierType).hitCount.inc();

--- a/server/src/main/java/org/opensearch/index/cache/request/ShardRequestCache.java
+++ b/server/src/main/java/org/opensearch/index/cache/request/ShardRequestCache.java
@@ -57,12 +57,19 @@ public final class ShardRequestCache {
         return new RequestCacheStats(statsHolder);
     }
 
-    public void onHit(TierType tierType) {
+    public void onHit(TierType tierType, double getTimeEWMA) {
         statsHolder.get(tierType).hitCount.inc();
+        if (tierType == TierType.DISK) {
+            statsHolder.get(tierType).getTimeEWMA = getTimeEWMA;
+        }
+
     }
 
-    public void onMiss(TierType tierType) {
+    public void onMiss(TierType tierType, double getTimeEWMA) {
         statsHolder.get(tierType).missCount.inc();
+        if (tierType == TierType.DISK) {
+            statsHolder.get(tierType).getTimeEWMA = getTimeEWMA;
+        }
     }
 
     public void onCached(Accountable key, BytesReference value, TierType tierType) {

--- a/server/src/main/java/org/opensearch/index/cache/request/ShardRequestCache.java
+++ b/server/src/main/java/org/opensearch/index/cache/request/ShardRequestCache.java
@@ -54,9 +54,6 @@ public final class ShardRequestCache {
     }
 
     public RequestCacheStats stats() {
-        // TODO: Change RequestCacheStats to support disk tier stats.
-        // Changing this function to return a RequestCacheStats with stats from all tiers.
-        // return stats(TierType.ON_HEAP);
         return new RequestCacheStats(statsHolder);
     }
 

--- a/server/src/main/java/org/opensearch/index/cache/request/StatsHolder.java
+++ b/server/src/main/java/org/opensearch/index/cache/request/StatsHolder.java
@@ -35,18 +35,25 @@ public class StatsHolder implements Serializable, Writeable, ToXContentFragment 
         this.entries = new CounterMetric();
     }
 
+    public StatsHolder(long evictions, long memorySize, long hitCount, long missCount, long entries) {
+        this.evictionsMetric = new CounterMetric();
+        this.evictionsMetric.inc(evictions);
+        this.totalMetric = new CounterMetric();
+        this.totalMetric.inc(memorySize);
+        this.hitCount = new CounterMetric();
+        this.hitCount.inc(hitCount);
+        this.missCount = new CounterMetric();
+        this.missCount.inc(missCount);
+        this.entries = new CounterMetric();
+        this.entries.inc(entries);
+    }
+
     public StatsHolder(StreamInput in) throws IOException  {
         // Read and write the values of the counter metrics. They should always be positive
-        this.evictionsMetric = new CounterMetric();
-        this.evictionsMetric.inc(in.readVLong());
-        this.totalMetric = new CounterMetric();
-        this.totalMetric.inc(in.readVLong());
-        this.hitCount = new CounterMetric();
-        this.hitCount.inc(in.readVLong());
-        this.missCount = new CounterMetric();
-        this.missCount.inc(in.readVLong());
-        this.entries = new CounterMetric();
-        this.entries.inc(in.readVLong());
+        // This object is new, so we shouldn't need version checks for different behavior
+        this(in.readVLong(), in.readVLong(), in.readVLong(), in.readVLong(), in.readVLong());
+        // java forces us to do this in one line
+        // guaranteed to be evaluated in correct order (https://docs.oracle.com/javase/specs/jls/se7/html/jls-15.html#jls-15.7.4)
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/index/cache/request/StatsHolder.java
+++ b/server/src/main/java/org/opensearch/index/cache/request/StatsHolder.java
@@ -20,26 +20,27 @@ import java.io.IOException;
 import java.io.Serializable;
 
 public class StatsHolder implements Serializable, Writeable, ToXContentFragment {
-    final CounterMetric evictionsMetric;
     final CounterMetric totalMetric;
+    final CounterMetric evictionsMetric;
     final CounterMetric hitCount;
     final CounterMetric missCount;
     final CounterMetric entries;
 
 
     public StatsHolder() {
-        this.evictionsMetric = new CounterMetric();
         this.totalMetric = new CounterMetric();
+        this.evictionsMetric = new CounterMetric();
         this.hitCount = new CounterMetric();
         this.missCount = new CounterMetric();
         this.entries = new CounterMetric();
     }
 
-    public StatsHolder(long evictions, long memorySize, long hitCount, long missCount, long entries) {
-        this.evictionsMetric = new CounterMetric();
-        this.evictionsMetric.inc(evictions);
+    public StatsHolder(long memorySize, long evictions, long hitCount, long missCount, long entries) {
+        // Switched argument order to match RequestCacheStats
         this.totalMetric = new CounterMetric();
         this.totalMetric.inc(memorySize);
+        this.evictionsMetric = new CounterMetric();
+        this.evictionsMetric.inc(evictions);
         this.hitCount = new CounterMetric();
         this.hitCount.inc(hitCount);
         this.missCount = new CounterMetric();
@@ -58,8 +59,8 @@ public class StatsHolder implements Serializable, Writeable, ToXContentFragment 
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeVLong(evictionsMetric.count());
         out.writeVLong(totalMetric.count());
+        out.writeVLong(evictionsMetric.count());
         out.writeVLong(hitCount.count());
         out.writeVLong(missCount.count());
         out.writeVLong(entries.count());
@@ -67,8 +68,8 @@ public class StatsHolder implements Serializable, Writeable, ToXContentFragment 
 
     public void add(StatsHolder otherStats) {
         // Add the argument's metrics to this object's metrics.
-        evictionsMetric.inc(otherStats.evictionsMetric.count());
         totalMetric.inc(otherStats.totalMetric.count());
+        evictionsMetric.inc(otherStats.evictionsMetric.count());
         hitCount.inc(otherStats.hitCount.count());
         missCount.inc(otherStats.missCount.count());
         entries.inc(otherStats.entries.count());

--- a/server/src/main/java/org/opensearch/index/cache/request/StatsHolder.java
+++ b/server/src/main/java/org/opensearch/index/cache/request/StatsHolder.java
@@ -1,0 +1,99 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.cache.request;
+
+import org.opensearch.common.metrics.CounterMetric;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.core.common.unit.ByteSizeValue;
+import org.opensearch.core.xcontent.ToXContentFragment;
+import org.opensearch.core.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.io.Serializable;
+
+public class StatsHolder implements Serializable, Writeable, ToXContentFragment {
+    final CounterMetric evictionsMetric;
+    final CounterMetric totalMetric;
+    final CounterMetric hitCount;
+    final CounterMetric missCount;
+    final CounterMetric entries;
+
+
+    public StatsHolder() {
+        this.evictionsMetric = new CounterMetric();
+        this.totalMetric = new CounterMetric();
+        this.hitCount = new CounterMetric();
+        this.missCount = new CounterMetric();
+        this.entries = new CounterMetric();
+    }
+
+    public StatsHolder(StreamInput in) throws IOException  {
+        // Read and write the values of the counter metrics. They should always be positive
+        this.evictionsMetric = new CounterMetric();
+        this.evictionsMetric.inc(in.readVLong());
+        this.totalMetric = new CounterMetric();
+        this.totalMetric.inc(in.readVLong());
+        this.hitCount = new CounterMetric();
+        this.hitCount.inc(in.readVLong());
+        this.missCount = new CounterMetric();
+        this.missCount.inc(in.readVLong());
+        this.entries = new CounterMetric();
+        this.entries.inc(in.readVLong());
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeVLong(evictionsMetric.count());
+        out.writeVLong(totalMetric.count());
+        out.writeVLong(hitCount.count());
+        out.writeVLong(missCount.count());
+        out.writeVLong(entries.count());
+    }
+
+    public void add(StatsHolder otherStats) {
+        // Add the argument's metrics to this object's metrics.
+        evictionsMetric.inc(otherStats.evictionsMetric.count());
+        totalMetric.inc(otherStats.totalMetric.count());
+        hitCount.inc(otherStats.hitCount.count());
+        missCount.inc(otherStats.missCount.count());
+        entries.inc(otherStats.entries.count());
+    }
+
+    public long getEvictions() {
+        return evictionsMetric.count();
+    }
+
+    public long getMemorySize() {
+        return totalMetric.count();
+    }
+
+    public long getHitCount() {
+        return hitCount.count();
+    }
+
+    public long getMissCount() {
+        return missCount.count();
+    }
+
+    public long getEntries() {
+        return entries.count();
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.humanReadableField(RequestCacheStats.Fields.MEMORY_SIZE_IN_BYTES, RequestCacheStats.Fields.MEMORY_SIZE, new ByteSizeValue(getMemorySize()));
+        builder.field(RequestCacheStats.Fields.EVICTIONS, getEvictions());
+        builder.field(RequestCacheStats.Fields.HIT_COUNT, getHitCount());
+        builder.field(RequestCacheStats.Fields.MISS_COUNT, getMissCount());
+        builder.field(RequestCacheStats.Fields.ENTRIES, getEntries());
+        return builder;
+    }
+}

--- a/server/src/main/java/org/opensearch/index/cache/request/StatsHolder.java
+++ b/server/src/main/java/org/opensearch/index/cache/request/StatsHolder.java
@@ -26,7 +26,6 @@ public class StatsHolder implements Serializable, Writeable, ToXContentFragment 
     final CounterMetric missCount;
     final CounterMetric entries;
 
-
     public StatsHolder() {
         this.totalMetric = new CounterMetric();
         this.evictionsMetric = new CounterMetric();
@@ -49,7 +48,7 @@ public class StatsHolder implements Serializable, Writeable, ToXContentFragment 
         this.entries.inc(entries);
     }
 
-    public StatsHolder(StreamInput in) throws IOException  {
+    public StatsHolder(StreamInput in) throws IOException {
         // Read and write the values of the counter metrics. They should always be positive
         // This object is new, so we shouldn't need version checks for different behavior
         this(in.readVLong(), in.readVLong(), in.readVLong(), in.readVLong(), in.readVLong());
@@ -97,7 +96,11 @@ public class StatsHolder implements Serializable, Writeable, ToXContentFragment 
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.humanReadableField(RequestCacheStats.Fields.MEMORY_SIZE_IN_BYTES, RequestCacheStats.Fields.MEMORY_SIZE, new ByteSizeValue(getMemorySize()));
+        builder.humanReadableField(
+            RequestCacheStats.Fields.MEMORY_SIZE_IN_BYTES,
+            RequestCacheStats.Fields.MEMORY_SIZE,
+            new ByteSizeValue(getMemorySize())
+        );
         builder.field(RequestCacheStats.Fields.EVICTIONS, getEvictions());
         builder.field(RequestCacheStats.Fields.HIT_COUNT, getHitCount());
         builder.field(RequestCacheStats.Fields.MISS_COUNT, getMissCount());

--- a/server/src/main/java/org/opensearch/indices/AbstractIndexShardCacheEntity.java
+++ b/server/src/main/java/org/opensearch/indices/AbstractIndexShardCacheEntity.java
@@ -56,13 +56,13 @@ abstract class AbstractIndexShardCacheEntity implements IndicesRequestCache.Cach
     }
 
     @Override
-    public final void onHit(TierType tierType) {
-        stats().onHit(tierType);
+    public final void onHit(TierType tierType, double getTimeEWMA) {
+        stats().onHit(tierType, getTimeEWMA);
     }
 
     @Override
-    public final void onMiss(TierType tierType) {
-        stats().onMiss(tierType);
+    public final void onMiss(TierType tierType, double getTimeEWMA) {
+        stats().onMiss(tierType, getTimeEWMA);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/indices/CachingTier.java
+++ b/server/src/main/java/org/opensearch/indices/CachingTier.java
@@ -10,8 +10,6 @@ package org.opensearch.indices;
 
 import org.opensearch.common.cache.RemovalListener;
 
-import java.io.IOException;
-
 /**
  * asdsadssa
  * @param <K>

--- a/server/src/main/java/org/opensearch/indices/DummySerializableKey.java
+++ b/server/src/main/java/org/opensearch/indices/DummySerializableKey.java
@@ -14,6 +14,7 @@ import java.util.Objects;
 public class DummySerializableKey implements Serializable {
     private Integer i;
     private String s;
+
     public DummySerializableKey(Integer i, String s) {
         this.i = i;
         this.s = s;
@@ -22,9 +23,11 @@ public class DummySerializableKey implements Serializable {
     public int getI() {
         return i;
     }
+
     public String getS() {
         return s;
     }
+
     @Override
     public boolean equals(Object o) {
         if (o == this) {
@@ -36,6 +39,7 @@ public class DummySerializableKey implements Serializable {
         DummySerializableKey other = (DummySerializableKey) o;
         return Objects.equals(this.i, other.i) && this.s.equals(other.s);
     }
+
     @Override
     public final int hashCode() {
         int result = 11;

--- a/server/src/main/java/org/opensearch/indices/EhcacheDiskCachingTier.java
+++ b/server/src/main/java/org/opensearch/indices/EhcacheDiskCachingTier.java
@@ -94,8 +94,6 @@ public class EhcacheDiskCachingTier implements DiskCachingTier<IndicesRequestCac
     }
 
     public void getManager() {
-        // based on https://stackoverflow.com/questions/53756412/ehcache-org-ehcache-statetransitionexception-persistence-directory-already-lo
-        // resolving double-initialization issue when using OpenSearchSingleNodeTestCase
         PersistentCacheManager oldCacheManager = cacheManagers.get(nodeId);
         if (oldCacheManager != null) {
             try {

--- a/server/src/main/java/org/opensearch/indices/EhcacheEventListener.java
+++ b/server/src/main/java/org/opensearch/indices/EhcacheEventListener.java
@@ -8,23 +8,26 @@
 
 package org.opensearch.indices;
 
-import org.ehcache.event.CacheEvent;
-import org.ehcache.event.CacheEventListener;
-import org.ehcache.event.EventType;
 import org.opensearch.common.cache.RemovalListener;
 import org.opensearch.common.cache.RemovalNotification;
 import org.opensearch.common.cache.RemovalReason;
 import org.opensearch.core.common.bytes.BytesReference;
+
+import org.ehcache.event.CacheEvent;
+import org.ehcache.event.CacheEventListener;
+import org.ehcache.event.EventType;
 
 public class EhcacheEventListener implements CacheEventListener<EhcacheKey, BytesReference> {
     // Receives key-value pairs (EhcacheKey, BytesReference), but must transform into (Key, BytesReference)
     // to send removal notifications
     private final RemovalListener<IndicesRequestCache.Key, BytesReference> removalListener;
     private final EhcacheDiskCachingTier tier;
+
     EhcacheEventListener(RemovalListener<IndicesRequestCache.Key, BytesReference> removalListener, EhcacheDiskCachingTier tier) {
         this.removalListener = removalListener;
         this.tier = tier; // needed to handle count changes
     }
+
     @Override
     public void onEvent(CacheEvent<? extends EhcacheKey, ? extends BytesReference> event) {
         EhcacheKey ehcacheKey = event.getKey();
@@ -50,7 +53,8 @@ public class EhcacheEventListener implements CacheEventListener<EhcacheKey, Byte
             case EXPIRED:
             case REMOVED:
                 reason = RemovalReason.INVALIDATED;
-                // this is probably fine for EXPIRED. We use cache.remove() to invalidate keys, but this might overlap with RemovalReason.EXPLICIT?
+                // this is probably fine for EXPIRED. We use cache.remove() to invalidate keys, but this might overlap with
+                // RemovalReason.EXPLICIT?
                 break;
             case UPDATED:
                 reason = RemovalReason.REPLACED;

--- a/server/src/main/java/org/opensearch/indices/IndicesRequestCache.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesRequestCache.java
@@ -151,8 +151,8 @@ public final class IndicesRequestCache implements TieredCacheEventListener<Indic
     }
 
     @Override
-    public void onMiss(Key key, TierType tierType) {
-        key.entity.onMiss(tierType);
+    public void onMiss(Key key, TierType tierType, double getTimeEWMA) {
+        key.entity.onMiss(tierType, getTimeEWMA);
     }
 
     @Override
@@ -161,8 +161,8 @@ public final class IndicesRequestCache implements TieredCacheEventListener<Indic
     }
 
     @Override
-    public void onHit(Key key, BytesReference value, TierType tierType) {
-        key.entity.onHit(tierType);
+    public void onHit(Key key, BytesReference value, TierType tierType, double getTimeEWMA) {
+        key.entity.onHit(tierType, getTimeEWMA);
     }
 
     @Override
@@ -275,12 +275,12 @@ public final class IndicesRequestCache implements TieredCacheEventListener<Indic
         /**
          * Called each time this entity has a cache hit.
          */
-        void onHit(TierType tierType);
+        void onHit(TierType tierType, double getTimeEWMA);
 
         /**
          * Called each time this entity has a cache miss.
          */
-        void onMiss(TierType tierType);
+        void onMiss(TierType tierType, double getTimeEWMA);
 
         /**
          * Called when this entity instance is removed

--- a/server/src/main/java/org/opensearch/indices/IndicesRequestCache.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesRequestCache.java
@@ -109,8 +109,10 @@ public final class IndicesRequestCache implements TieredCacheEventListener<Indic
     private final IndicesService indicesService;
     // private final Cache<Key, BytesReference> cache;
 
-    //private final TieredCacheHandler<Key, BytesReference> tieredCacheHandler;
-    public final TieredCacheSpilloverStrategyHandler<Key, BytesReference> tieredCacheHandler; // Change this back after done debugging serialization issues
+    // private final TieredCacheHandler<Key, BytesReference> tieredCacheHandler;
+    public final TieredCacheSpilloverStrategyHandler<Key, BytesReference> tieredCacheHandler; // Change this back after done debugging
+                                                                                              // serialization issues
+
     IndicesRequestCache(Settings settings, IndicesService indicesService) {
         this.size = INDICES_CACHE_QUERY_SIZE.get(settings);
         this.expire = INDICES_CACHE_QUERY_EXPIRE.exists(settings) ? INDICES_CACHE_QUERY_EXPIRE.get(settings) : null;
@@ -140,6 +142,7 @@ public final class IndicesRequestCache implements TieredCacheEventListener<Indic
     @Override
     public void close() {
         tieredCacheHandler.invalidateAll();
+        tieredCacheHandler.closeDiskTier();
     }
 
     void clear(CacheEntity entity) {

--- a/server/src/main/java/org/opensearch/indices/TierType.java
+++ b/server/src/main/java/org/opensearch/indices/TierType.java
@@ -10,6 +10,17 @@ package org.opensearch.indices;
 
 public enum TierType {
 
-    ON_HEAP,
-    DISK;
+    ON_HEAP("on_heap"),
+    DISK("disk");
+
+    private final String stringValue;
+
+    TierType(String stringValue) {
+        // Associate each TierType with a string representation, for use in API responses and elsewhere
+        this.stringValue = stringValue;
+    }
+
+    public String getStringValue() {
+        return this.stringValue;
+    }
 }

--- a/server/src/main/java/org/opensearch/indices/TieredCacheEventListener.java
+++ b/server/src/main/java/org/opensearch/indices/TieredCacheEventListener.java
@@ -12,11 +12,11 @@ import org.opensearch.common.cache.RemovalNotification;
 
 public interface TieredCacheEventListener<K, V> {
 
-    void onMiss(K key, TierType tierType);
+    void onMiss(K key, TierType tierType, double getTimeEWMA);
 
     void onRemoval(RemovalNotification<K, V> notification);
 
-    void onHit(K key, V value, TierType tierType);
+    void onHit(K key, V value, TierType tierType, double getTimeEWMA);
 
     void onCached(K key, V value, TierType tierType);
 }

--- a/server/src/main/java/org/opensearch/indices/TieredCacheSpilloverStrategyHandler.java
+++ b/server/src/main/java/org/opensearch/indices/TieredCacheSpilloverStrategyHandler.java
@@ -140,6 +140,7 @@ public class TieredCacheSpilloverStrategyHandler<K extends Writeable, V> impleme
             return null;
         };
     }
+
     @Override
     public void closeDiskTier() {
         diskCachingTier.close();

--- a/server/src/main/java/org/opensearch/indices/TieredCacheSpilloverStrategyHandler.java
+++ b/server/src/main/java/org/opensearch/indices/TieredCacheSpilloverStrategyHandler.java
@@ -54,8 +54,6 @@ public class TieredCacheSpilloverStrategyHandler<K extends Writeable, V> impleme
             V value = onHeapCachingTier.compute(key, loader);
             tieredCacheEventListener.onCached(key, value, TierType.ON_HEAP);
             return value;
-        } else {
-            //tieredCacheEventListener.onHit(key, cacheValue.value, cacheValue.source); // this double counts, see line 122
         }
         return cacheValue.value;
     }
@@ -105,6 +103,7 @@ public class TieredCacheSpilloverStrategyHandler<K extends Writeable, V> impleme
             switch (notification.getTierType()) {
                 case ON_HEAP:
                     diskCachingTier.put(notification.getKey(), notification.getValue());
+
                     break;
                 default:
                     break;

--- a/server/src/main/resources/org/opensearch/bootstrap/security.policy
+++ b/server/src/main/resources/org/opensearch/bootstrap/security.policy
@@ -192,6 +192,8 @@ grant {
   permission java.lang.RuntimePermission "createClassLoader";
   permission java.lang.RuntimePermission "accessClassInPackage.sun.misc";
   permission java.lang.RuntimePermission "getenv.*";
+  permission java.lang.RuntimePermission "accessDeclaredMembers";
+  permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
   permission java.io.FilePermission "disk_cache_tier", "read"; // change this to wherever we will put disk tier folder
   permission java.io.FilePermission "disk_cache_tier", "write";
   permission java.io.FilePermission "disk_cache_tier", "delete";

--- a/server/src/test/java/org/opensearch/index/cache/request/RequestCacheStatsTests.java
+++ b/server/src/test/java/org/opensearch/index/cache/request/RequestCacheStatsTests.java
@@ -10,14 +10,10 @@ package org.opensearch.index.cache.request;
 
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.core.common.bytes.BytesReference;
-import org.opensearch.core.common.io.stream.BytesStream;
 import org.opensearch.core.common.io.stream.BytesStreamInput;
-import org.opensearch.core.common.io.stream.StreamInput;
-import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.indices.TierType;
 import org.opensearch.test.OpenSearchTestCase;
 
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -28,9 +24,7 @@ public class RequestCacheStatsTests extends OpenSearchTestCase {
             assertTierState(emptyStats, tierType, 0, 0, 0, 0, 0);
         }
         Map<TierType, StatsHolder> testHeapMap = new HashMap<>();
-        testHeapMap.put(TierType.ON_HEAP, new StatsHolder(
-            1, 2, 3, 4, 5
-        ));
+        testHeapMap.put(TierType.ON_HEAP, new StatsHolder(1, 2, 3, 4, 5));
         RequestCacheStats heapOnlyStats = new RequestCacheStats(testHeapMap);
         for (TierType tierType : TierType.values()) {
             if (tierType == TierType.ON_HEAP) {
@@ -41,12 +35,8 @@ public class RequestCacheStatsTests extends OpenSearchTestCase {
         }
 
         Map<TierType, StatsHolder> testBothTiersMap = new HashMap<>();
-        testBothTiersMap.put(TierType.ON_HEAP, new StatsHolder(
-            11, 12, 13, 14, 15
-        ));
-        testBothTiersMap.put(TierType.DISK, new StatsHolder(
-            6, 7, 8, 9, 10
-        ));
+        testBothTiersMap.put(TierType.ON_HEAP, new StatsHolder(11, 12, 13, 14, 15));
+        testBothTiersMap.put(TierType.DISK, new StatsHolder(6, 7, 8, 9, 10));
         RequestCacheStats bothTiersStats = new RequestCacheStats(testBothTiersMap);
         assertTierState(bothTiersStats, TierType.ON_HEAP, 11, 12, 13, 14, 15);
         assertTierState(bothTiersStats, TierType.DISK, 6, 7, 8, 9, 10);
@@ -57,16 +47,12 @@ public class RequestCacheStatsTests extends OpenSearchTestCase {
     }
 
     public void testSerialization() throws Exception {
-        // This test also implicitly tests StreamHolder serialization
+        // This test also implicitly tests StatsHolder serialization
         BytesStreamOutput os = new BytesStreamOutput();
 
         Map<TierType, StatsHolder> testMap = new HashMap<>();
-        testMap.put(TierType.ON_HEAP, new StatsHolder(
-            11, 12, 13, 14, 15
-        ));
-        testMap.put(TierType.DISK, new StatsHolder(
-            6, 7, 8, 9, 10
-        ));
+        testMap.put(TierType.ON_HEAP, new StatsHolder(11, 12, 13, 14, 15));
+        testMap.put(TierType.DISK, new StatsHolder(6, 7, 8, 9, 10));
         RequestCacheStats stats = new RequestCacheStats(testMap);
         stats.writeTo(os);
         BytesStreamInput is = new BytesStreamInput(BytesReference.toBytes(os.bytes()));
@@ -91,5 +77,4 @@ public class RequestCacheStatsTests extends OpenSearchTestCase {
         assertEquals(missCount, stats.getMissCount(tierType));
         assertEquals(entries, stats.getEntries(tierType));
     }
-
 }

--- a/server/src/test/java/org/opensearch/index/cache/request/RequestCacheStatsTests.java
+++ b/server/src/test/java/org/opensearch/index/cache/request/RequestCacheStatsTests.java
@@ -1,0 +1,95 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.cache.request;
+
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.common.io.stream.BytesStream;
+import org.opensearch.core.common.io.stream.BytesStreamInput;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.indices.TierType;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+public class RequestCacheStatsTests extends OpenSearchTestCase {
+    public void testConstructorsAndAdd() throws Exception {
+        RequestCacheStats emptyStats = new RequestCacheStats();
+        for (TierType tierType : TierType.values()) {
+            assertTierState(emptyStats, tierType, 0, 0, 0, 0, 0);
+        }
+        Map<TierType, StatsHolder> testHeapMap = new HashMap<>();
+        testHeapMap.put(TierType.ON_HEAP, new StatsHolder(
+            1, 2, 3, 4, 5
+        ));
+        RequestCacheStats heapOnlyStats = new RequestCacheStats(testHeapMap);
+        for (TierType tierType : TierType.values()) {
+            if (tierType == TierType.ON_HEAP) {
+                assertTierState(heapOnlyStats, tierType, 1, 2, 3, 4, 5);
+            } else {
+                assertTierState(heapOnlyStats, tierType, 0, 0, 0, 0, 0);
+            }
+        }
+
+        Map<TierType, StatsHolder> testBothTiersMap = new HashMap<>();
+        testBothTiersMap.put(TierType.ON_HEAP, new StatsHolder(
+            11, 12, 13, 14, 15
+        ));
+        testBothTiersMap.put(TierType.DISK, new StatsHolder(
+            6, 7, 8, 9, 10
+        ));
+        RequestCacheStats bothTiersStats = new RequestCacheStats(testBothTiersMap);
+        assertTierState(bothTiersStats, TierType.ON_HEAP, 11, 12, 13, 14, 15);
+        assertTierState(bothTiersStats, TierType.DISK, 6, 7, 8, 9, 10);
+
+        bothTiersStats.add(heapOnlyStats);
+        assertTierState(bothTiersStats, TierType.ON_HEAP, 12, 14, 16, 18, 20);
+        assertTierState(bothTiersStats, TierType.DISK, 6, 7, 8, 9, 10);
+    }
+
+    public void testSerialization() throws Exception {
+        // This test also implicitly tests StreamHolder serialization
+        BytesStreamOutput os = new BytesStreamOutput();
+
+        Map<TierType, StatsHolder> testMap = new HashMap<>();
+        testMap.put(TierType.ON_HEAP, new StatsHolder(
+            11, 12, 13, 14, 15
+        ));
+        testMap.put(TierType.DISK, new StatsHolder(
+            6, 7, 8, 9, 10
+        ));
+        RequestCacheStats stats = new RequestCacheStats(testMap);
+        stats.writeTo(os);
+        BytesStreamInput is = new BytesStreamInput(BytesReference.toBytes(os.bytes()));
+        RequestCacheStats deserialized = new RequestCacheStats(is);
+
+        assertTierState(deserialized, TierType.ON_HEAP, 11, 12, 13, 14, 15);
+        assertTierState(deserialized, TierType.DISK, 6, 7, 8, 9, 10);
+    }
+
+    private void assertTierState(
+        RequestCacheStats stats,
+        TierType tierType,
+        long memSize,
+        long evictions,
+        long hitCount,
+        long missCount,
+        long entries
+    ) {
+        assertEquals(memSize, stats.getMemorySizeInBytes(tierType));
+        assertEquals(evictions, stats.getEvictions(tierType));
+        assertEquals(hitCount, stats.getHitCount(tierType));
+        assertEquals(missCount, stats.getMissCount(tierType));
+        assertEquals(entries, stats.getEntries(tierType));
+    }
+
+}

--- a/server/src/test/java/org/opensearch/indices/IndicesRequestCacheTests.java
+++ b/server/src/test/java/org/opensearch/indices/IndicesRequestCacheTests.java
@@ -151,7 +151,7 @@ public class IndicesRequestCacheTests extends OpenSearchSingleNodeTestCase {
         String rKey = ((OpenSearchDirectoryReader) reader).getDelegatingCacheHelper().getDelegatingCacheKey().getId().toString();
         IndicesRequestCache.Key key = cache.new Key(entity, termBytes, rKey);
 
-        BytesReference value = new BytesArray(new byte[]{0});
+        BytesReference value = new BytesArray(new byte[] { 0 });
         cache.tieredCacheHandler.getDiskCachingTier().put(key, value);
 
         BytesReference res = cache.tieredCacheHandler.getDiskCachingTier().get(key);

--- a/server/src/test/java/org/opensearch/indices/IndicesRequestCacheTests.java
+++ b/server/src/test/java/org/opensearch/indices/IndicesRequestCacheTests.java
@@ -180,7 +180,6 @@ public class IndicesRequestCacheTests extends OpenSearchSingleNodeTestCase {
 
         TestEntity entity = new TestEntity(requestCacheStats, indexShard);
         Loader loader = new Loader(reader, 0);
-        System.out.println("On-heap cache size at start = " + requestCacheStats.stats().getMemorySizeInBytes());
         BytesReference[] termBytesArr = new BytesReference[maxNumInHeap + 1];
 
         for (int i = 0; i < maxNumInHeap + 1; i++) {

--- a/server/src/test/java/org/opensearch/indices/IndicesRequestCacheTests.java
+++ b/server/src/test/java/org/opensearch/indices/IndicesRequestCacheTests.java
@@ -196,8 +196,8 @@ public class IndicesRequestCacheTests extends OpenSearchSingleNodeTestCase {
         assertEquals(maxNumInHeap * heapKeySize, requestCacheStats.stats().getMemorySizeInBytes());
         // TODO: disk weight bytes
         assertEquals(1, requestCacheStats.stats().getEvictions());
-        assertEquals(1, requestCacheStats.stats(TierType.DISK).getHitCount());
-        assertEquals(maxNumInHeap + 1, requestCacheStats.stats(TierType.DISK).getMissCount());
+        assertEquals(1, requestCacheStats.stats().getHitCount(TierType.DISK));
+        assertEquals(maxNumInHeap + 1, requestCacheStats.stats().getMissCount(TierType.DISK));
         assertEquals(0, requestCacheStats.stats().getHitCount());
         assertEquals(maxNumInHeap + 2, requestCacheStats.stats().getMissCount());
         assertEquals(maxNumInHeap, cache.tieredCacheHandler.count(TierType.ON_HEAP));
@@ -209,8 +209,8 @@ public class IndicesRequestCacheTests extends OpenSearchSingleNodeTestCase {
         BytesReference firstValueAgain = cache.getOrCompute(entity, loader, reader, termBytesArr[0]);
 
         assertEquals(1, requestCacheStats.stats().getEvictions());
-        assertEquals(2, requestCacheStats.stats(TierType.DISK).getHitCount());
-        assertEquals(maxNumInHeap + 1, requestCacheStats.stats(TierType.DISK).getMissCount());
+        assertEquals(2, requestCacheStats.stats().getHitCount(TierType.DISK));
+        assertEquals(maxNumInHeap + 1, requestCacheStats.stats().getMissCount(TierType.DISK));
         assertEquals(1, requestCacheStats.stats().getHitCount());
         assertEquals(maxNumInHeap + 3, requestCacheStats.stats().getMissCount());
         assertEquals(maxNumInHeap, cache.tieredCacheHandler.count(TierType.ON_HEAP));

--- a/server/src/test/java/org/opensearch/indices/IndicesServiceCloseTests.java
+++ b/server/src/test/java/org/opensearch/indices/IndicesServiceCloseTests.java
@@ -341,10 +341,10 @@ public class IndicesServiceCloseTests extends OpenSearchTestCase {
             }
 
             @Override
-            public void onHit(TierType tierType) {}
+            public void onHit(TierType tierType, double getTimeEWMA) {}
 
             @Override
-            public void onMiss(TierType tierType) {}
+            public void onMiss(TierType tierType, double getTimeEWMA) {}
 
             @Override
             public void onRemoval(RemovalNotification<Key, BytesReference> notification) {}


### PR DESCRIPTION
### Description
Modifies the request cache's API to return statistics for additional cache tiers, like the upcoming disk tier. Also adds the number of entries to the response. Stats for the existing on-heap tier stayed where they were, in the "request_cache" object. This object has a new field, the "tiers" object. Each new tier, besides the on-heap tier, will have its stats returned here. If a certain tier is not enabled, its statistics will still be returned, with all its values set to 0. 

Calling _nodes/stats/indices/request_cache now returns the following: 

```{
  "_nodes": {
    "total": 1,
    "successful": 1,
    "failed": 0
  },
  "cluster_name": "runTask",
  "nodes": {
    "3Xx_SnhhQACQu5jW9UJGrQ": {
      "timestamp": 1698099482892,
      "name": "runTask-0",
      "transport_address": "127.0.0.1:9300",
      "host": "127.0.0.1",
      "ip": "127.0.0.1:9300",
      "roles": [
        "cluster_manager",
        "data",
        "ingest",
        "remote_cluster_client"
      ],
      "attributes": {
        "testattr": "test",
        "shard_indexing_pressure_enabled": "true"
      },
      "indices": {
        "request_cache": {
          "memory_size_in_bytes": 0,
          "evictions": 0,
          "hit_count": 0,
          "miss_count": 0,
          "entries": 0,
          "tiers": {
            "disk": {
              "memory_size_in_bytes": 0,
              "evictions": 0,
              "hit_count": 0,
              "miss_count": 0,
              "entries": 0
            }
          }
        }
      }
    }
  }
}
```

Tested with unit tests for the overhauled RequestCacheStats, an integration test, and manual testing with the API. 

### Related Issues
Part of larger [tiered caching feature](https://github.com/opensearch-project/OpenSearch/issues/10024). 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff
- [N/A] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
