### PR TITLE
Adds Serializer interface for use in ehcache disk tier and elsewhere;…

### DIFF
--- a/server/src/main/java/org/opensearch/common/cache/tier/BytesReferenceSerializer.java
+++ b/server/src/main/java/org/opensearch/common/cache/tier/BytesReferenceSerializer.java
@@ -1,0 +1,35 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.cache.tier;
+
+import org.opensearch.core.common.bytes.BytesArray;
+import org.opensearch.core.common.bytes.BytesReference;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+public class BytesReferenceSerializer implements Serializer<BytesReference, byte[]> {
+    // This class does not get passed to ehcache itself, so it's not required that classes match after deserialization.
+
+    public BytesReferenceSerializer() {}
+    @Override
+    public byte[] serialize(BytesReference object) {
+        return BytesReference.toBytes(object);
+    }
+
+    @Override
+    public BytesReference deserialize(byte[] bytes) {
+        return new BytesArray(bytes);
+    }
+
+    @Override
+    public boolean equals(BytesReference object, byte[] bytes) {
+        return Arrays.equals(serialize(object), bytes);
+    }
+}

--- a/server/src/main/java/org/opensearch/common/cache/tier/EhCacheDiskCachingTier.java
+++ b/server/src/main/java/org/opensearch/common/cache/tier/EhCacheDiskCachingTier.java
@@ -44,14 +44,6 @@ import org.ehcache.expiry.ExpiryPolicy;
 import org.ehcache.impl.config.store.disk.OffHeapDiskStoreConfiguration;
 
 /**
- * This ehcache disk caching tier uses its value serializer outside ehcache.
- * Values are transformed to byte[] outside ehcache and then ehcache uses its bundled byte[] serializer.
- * The key serializer you pass to this class produces a byte[]. This serializer is passed to a wrapper which
- * implements Ehcache's serializer implementation and produces a BytesBuffer. The wrapper instance is then passed to ehcache.
- * This is done because to get keys on a disk tier, ehcache internally checks the equals() method of the serializer,
- * but ALSO requires newKey.equals(storedKey) (this isn't documented), which is the case for ByteBuffer but not byte[].
- * This limitation means that the key serializer must preserve the class of the key before/after serialization,
- * but the value serializer does not have to do this.
  * @param <K> The key type of cache entries
  * @param <V> The value type of cache entries
  */
@@ -293,7 +285,8 @@ public class EhCacheDiskCachingTier<K, V> implements DiskCachingTier<K, V> {
                             new RemovalNotification<>(
                                 event.getKey(),
                                 valueSerializer.deserialize(event.getOldValue()),
-                                RemovalReason.EVICTED
+                                RemovalReason.EVICTED,
+                                TierType.DISK
                             )
                         )
                     );
@@ -310,7 +303,8 @@ public class EhCacheDiskCachingTier<K, V> implements DiskCachingTier<K, V> {
                             new RemovalNotification<>(
                                 event.getKey(),
                                 valueSerializer.deserialize(event.getOldValue()),
-                                RemovalReason.INVALIDATED
+                                RemovalReason.INVALIDATED,
+                                TierType.DISK
                             )
                         )
                     );

--- a/server/src/main/java/org/opensearch/common/cache/tier/Serializer.java
+++ b/server/src/main/java/org/opensearch/common/cache/tier/Serializer.java
@@ -1,0 +1,39 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.cache.tier;
+
+import java.io.IOException;
+
+/**
+ * An interface for serializers, to be used in disk caching tier and elsewhere.
+ * T is the class of the original object, and U is the serialized class.
+ */
+public interface Serializer<T, U> {
+    /**
+     * Serializes an object.
+     * @param object A non-serialized object.
+     * @return The serialized representation of the object.
+     */
+    U serialize(T object);
+
+    /**
+     * Deserializes bytes into an object.
+     * @param bytes The serialized representation.
+     * @return The original object.
+     */
+    T deserialize(U bytes);
+
+    /**
+     * Compares an object to a serialized representation of an object.
+     * @param object A non-serialized objet
+     * @param bytes Serialized representation of an object
+     * @return true if representing the same object, false if not
+     */
+    boolean equals(T object, U bytes);
+}

--- a/server/src/test/java/org/opensearch/common/cache/tier/BytesReferenceSerializerTests.java
+++ b/server/src/test/java/org/opensearch/common/cache/tier/BytesReferenceSerializerTests.java
@@ -1,0 +1,61 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.cache.tier;
+
+import org.opensearch.common.Randomness;
+import org.opensearch.common.bytes.ReleasableBytesReference;
+import org.opensearch.common.util.BigArrays;
+import org.opensearch.common.util.PageCacheRecycler;
+import org.opensearch.core.common.bytes.BytesArray;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.common.bytes.CompositeBytesReference;
+import org.opensearch.core.common.util.ByteArray;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.Random;
+
+public class BytesReferenceSerializerTests extends OpenSearchTestCase {
+    public void testEquality() throws Exception {
+        BytesReferenceSerializer ser = new BytesReferenceSerializer();
+        // Test that values are equal before and after serialization, for each implementation of BytesReference.
+        byte[] bytesValue = new byte[1000];
+        Random rand = Randomness.get();
+        rand.nextBytes(bytesValue);
+
+        BytesReference ba = new BytesArray(bytesValue);
+        byte[] serialized = ser.serialize(ba);
+        assertTrue(ser.equals(ba, serialized));
+        BytesReference deserialized = ser.deserialize(serialized);
+        assertEquals(ba, deserialized);
+
+        BytesReference cbr = CompositeBytesReference.of(new BytesArray(bytesValue), new BytesArray(bytesValue));
+        serialized = ser.serialize(cbr);
+        assertTrue(ser.equals(cbr, serialized));
+        deserialized = ser.deserialize(serialized);
+        assertEquals(cbr, deserialized);
+
+        // We need the PagedBytesReference to be larger than the page size (16 KB) in order to actually create it
+        byte[] pbrValue = new byte[PageCacheRecycler.PAGE_SIZE_IN_BYTES * 2];
+        rand.nextBytes(pbrValue);
+        ByteArray arr = BigArrays.NON_RECYCLING_INSTANCE.newByteArray(pbrValue.length);
+        arr.set(0L, pbrValue, 0, pbrValue.length);
+        assert !arr.hasArray();
+        BytesReference pbr = BytesReference.fromByteArray(arr, pbrValue.length);
+        serialized = ser.serialize(pbr);
+        assertTrue(ser.equals(pbr, serialized));
+        deserialized = ser.deserialize(serialized);
+        assertEquals(pbr, deserialized);
+
+        BytesReference rbr = new ReleasableBytesReference(new BytesArray(bytesValue), ReleasableBytesReference.NO_OP);
+        serialized = ser.serialize(rbr);
+        assertTrue(ser.equals(rbr, serialized));
+        deserialized = ser.deserialize(serialized);
+        assertEquals(rbr, deserialized);
+    }
+}

--- a/server/src/test/java/org/opensearch/common/cache/tier/EhCacheDiskCachingTierTests.java
+++ b/server/src/test/java/org/opensearch/common/cache/tier/EhCacheDiskCachingTierTests.java
@@ -74,7 +74,7 @@ public class EhCacheDiskCachingTierTests extends OpenSearchSingleNodeTestCase {
                 .setExpireAfterAccess(TimeValue.MAX_VALUE)
                 .setSettings(settings)
                 .setThreadPoolAlias("ehcacheTest")
-                .setMaximumWeightInBytes(CACHE_SIZE_IN_BYTES)
+                .setMaximumWeightInBytes(CACHE_SIZE_IN_BYTES * 2)
                 .setStoragePath(env.nodePaths()[0].indicesPath.toString() + "/request_cache")
                 .setSettingPrefix(SETTING_PREFIX)
                 .setKeySerializer(new StringSerializer())


### PR DESCRIPTION
### Description
Added Serializer interface to Sagar's ehcache disk tier implementation. We pass the disk tier a key and a value serializer which serialize objects to byte[]. 

The value serializer is used outside of ehcache, in the disk tier's put() and get(). This saves us from having to serialize BytesReference objects such that their class is the same before and after serialization, which would have been very hacky and potentially damaged performance in other places in OpenSearch. (BytesReference is an interface and its implementing classes are not always simple to instantiate). Ehcache requires this class constraint, but the rest of OS does not care which type of BytesReference something is, so we can move our serializer outside ehcache for a cleaner implementation. 

The key serializer is put into a wrapper that outputs ByteBuffer objects and implements ehcache's serializer interface. The wrapper instance is then passed directly to ehcache. We cannot use byte[] directly as a key, despite ehcache having a bundled serializer for it, because when searching for a key it checks both the equals() method of the bundled serializer and also the equals() method of the keys themselves (this is not documented). This means the key serializer must preserve class before and after serialization, but we don't expect this to be a problem. 

The implementation is generic and can be used for any EhcacheDiskCachingTier<K, V> so long as serializer implementations for K and V are provided. 

### Related Issues
Part of larger tiered caching feature. 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  ~- [N/A] New functionality has javadoc added~
- [x] Commits are signed per the DCO using --signoff
~- [N/A] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))~
~- [N/A] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
