### PR TITLE
Added/tested get time EWMA to non-heap tiers for node stats response

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/indices/IndicesRequestCacheIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/indices/IndicesRequestCacheIT.java
@@ -43,7 +43,6 @@ import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.time.DateFormatter;
 import org.opensearch.common.util.FeatureFlags;
-import org.opensearch.core.common.unit.ByteSizeValue;
 import org.opensearch.index.cache.request.RequestCacheStats;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.search.aggregations.bucket.global.GlobalAggregationBuilder;

--- a/server/src/main/java/org/opensearch/index/cache/request/ShardRequestCache.java
+++ b/server/src/main/java/org/opensearch/index/cache/request/ShardRequestCache.java
@@ -57,12 +57,19 @@ public final class ShardRequestCache {
         return new RequestCacheStats(statsHolder);
     }
 
-    public void onHit(TierType tierType) {
+    public void onHit(TierType tierType, double getTimeEWMA) {
         statsHolder.get(tierType).hitCount.inc();
+        if (tierType == TierType.DISK) {
+            statsHolder.get(tierType).getTimeEWMA = getTimeEWMA;
+        }
+
     }
 
-    public void onMiss(TierType tierType) {
+    public void onMiss(TierType tierType, double getTimeEWMA) {
         statsHolder.get(tierType).missCount.inc();
+        if (tierType == TierType.DISK) {
+            statsHolder.get(tierType).getTimeEWMA = getTimeEWMA;
+        }
     }
 
     public void onCached(Accountable key, BytesReference value, TierType tierType) {

--- a/server/src/main/java/org/opensearch/indices/AbstractIndexShardCacheEntity.java
+++ b/server/src/main/java/org/opensearch/indices/AbstractIndexShardCacheEntity.java
@@ -56,13 +56,13 @@ abstract class AbstractIndexShardCacheEntity implements IndicesRequestCache.Cach
     }
 
     @Override
-    public final void onHit(TierType tierType) {
-        stats().onHit(tierType);
+    public final void onHit(TierType tierType, double getTimeEWMA) {
+        stats().onHit(tierType, getTimeEWMA);
     }
 
     @Override
-    public final void onMiss(TierType tierType) {
-        stats().onMiss(tierType);
+    public final void onMiss(TierType tierType, double getTimeEWMA) {
+        stats().onMiss(tierType, getTimeEWMA);
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/indices/IndicesRequestCache.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesRequestCache.java
@@ -151,8 +151,8 @@ public final class IndicesRequestCache implements TieredCacheEventListener<Indic
     }
 
     @Override
-    public void onMiss(Key key, TierType tierType) {
-        key.entity.onMiss(tierType);
+    public void onMiss(Key key, TierType tierType, double getTimeEWMA) {
+        key.entity.onMiss(tierType, getTimeEWMA);
     }
 
     @Override
@@ -161,8 +161,8 @@ public final class IndicesRequestCache implements TieredCacheEventListener<Indic
     }
 
     @Override
-    public void onHit(Key key, BytesReference value, TierType tierType) {
-        key.entity.onHit(tierType);
+    public void onHit(Key key, BytesReference value, TierType tierType, double getTimeEWMA) {
+        key.entity.onHit(tierType, getTimeEWMA);
     }
 
     @Override
@@ -275,12 +275,12 @@ public final class IndicesRequestCache implements TieredCacheEventListener<Indic
         /**
          * Called each time this entity has a cache hit.
          */
-        void onHit(TierType tierType);
+        void onHit(TierType tierType, double getTimeEWMA);
 
         /**
          * Called each time this entity has a cache miss.
          */
-        void onMiss(TierType tierType);
+        void onMiss(TierType tierType, double getTimeEWMA);
 
         /**
          * Called when this entity instance is removed

--- a/server/src/main/java/org/opensearch/indices/TieredCacheEventListener.java
+++ b/server/src/main/java/org/opensearch/indices/TieredCacheEventListener.java
@@ -12,11 +12,11 @@ import org.opensearch.common.cache.RemovalNotification;
 
 public interface TieredCacheEventListener<K, V> {
 
-    void onMiss(K key, TierType tierType);
+    void onMiss(K key, TierType tierType, double getTimeEWMA);
 
     void onRemoval(RemovalNotification<K, V> notification);
 
-    void onHit(K key, V value, TierType tierType);
+    void onHit(K key, V value, TierType tierType, double getTimeEWMA);
 
     void onCached(K key, V value, TierType tierType);
 }

--- a/server/src/test/java/org/opensearch/indices/IndicesRequestCacheTests.java
+++ b/server/src/test/java/org/opensearch/indices/IndicesRequestCacheTests.java
@@ -180,7 +180,6 @@ public class IndicesRequestCacheTests extends OpenSearchSingleNodeTestCase {
 
         TestEntity entity = new TestEntity(requestCacheStats, indexShard);
         Loader loader = new Loader(reader, 0);
-        System.out.println("On-heap cache size at start = " + requestCacheStats.stats().getMemorySizeInBytes());
         BytesReference[] termBytesArr = new BytesReference[maxNumInHeap + 1];
 
         for (int i = 0; i < maxNumInHeap + 1; i++) {

--- a/server/src/test/java/org/opensearch/indices/IndicesServiceCloseTests.java
+++ b/server/src/test/java/org/opensearch/indices/IndicesServiceCloseTests.java
@@ -341,10 +341,10 @@ public class IndicesServiceCloseTests extends OpenSearchTestCase {
             }
 
             @Override
-            public void onHit(TierType tierType) {}
+            public void onHit(TierType tierType, double getTimeEWMA) {}
 
             @Override
-            public void onMiss(TierType tierType) {}
+            public void onMiss(TierType tierType, double getTimeEWMA) {}
 
             @Override
             public void onRemoval(RemovalNotification<Key, BytesReference> notification) {}


### PR DESCRIPTION
### Description
Adds an EWMA for get time to the node stats response for non-heap tiers, like the upcoming disk tier. Intended as a tweak for #8. 

Calling _nodes/stats/indices/request_cache now returns the following: 
```{
  "_nodes": {
    "total": 1,
    "successful": 1,
    "failed": 0
  },
  "cluster_name": "runTask",
  "nodes": {
    "ze65wfe0SiO1-BiQMvCNTQ": {
      "timestamp": 1699297297377,
      "name": "runTask-0",
      "transport_address": "127.0.0.1:9300",
      "host": "127.0.0.1",
      "ip": "127.0.0.1:9300",
      "roles": [
        "cluster_manager",
        "data",
        "ingest",
        "remote_cluster_client"
      ],
      "attributes": {
        "testattr": "test",
        "shard_indexing_pressure_enabled": "true"
      },
      "indices": {
        "request_cache": {
          "memory_size_in_bytes": 1368,
          "evictions": 0,
          "hit_count": 40,
          "miss_count": 40,
          "entries": 2,
          "tiers": {
            "disk": {
              "memory_size_in_bytes": 0,
              "evictions": 0,
              "hit_count": 0,
              "miss_count": 40,
              "entries": 0,
              "get_time_ewma_millis": 0.040995631587434765
            }
          }
        }
      }
    }
  }
}```

Tested with unit tests, IT test, and manually (producing above response). 

### Related Issues
Part of larger [tiered caching](https://github.com/opensearch-project/OpenSearch/issues/10024) feature. 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [N/A] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [N/A] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [N/A] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
