### PR TITLE
Fixes RamUsageEstimator performance issue in tiered caching framework

### DIFF
--- a/server/src/main/java/org/opensearch/indices/IndicesRequestCache.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesRequestCache.java
@@ -161,6 +161,7 @@ public final class IndicesRequestCache implements TieredCacheEventListener<Indic
     private final IndicesService indicesService;
     private final Settings settings;
     private final ClusterSettings clusterSettings;
+    protected final static long keyInstanceSize = RamUsageEstimator.shallowSizeOfInstance(Key.class);
 
     IndicesRequestCache(Settings settings, IndicesService indicesService, ClusterSettings clusterSettings) {
         this.size = INDICES_CACHE_QUERY_SIZE.get(settings);
@@ -459,7 +460,7 @@ public final class IndicesRequestCache implements TieredCacheEventListener<Indic
      * @opensearch.internal
      */
     class Key implements Accountable, Writeable {
-        private final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(Key.class);
+        private final long BASE_RAM_BYTES_USED = IndicesRequestCache.keyInstanceSize;
 
         public final CacheEntity entity; // use as identity equality
         public final String readerCacheKeyId;

--- a/server/src/main/java/org/opensearch/indices/IndicesService.java
+++ b/server/src/main/java/org/opensearch/indices/IndicesService.java
@@ -404,6 +404,11 @@ public class IndicesService extends AbstractLifecycleComponent
 
     private final SearchRequestStats searchRequestStats;
 
+    // Moved this computation out here to prevent recomputing the size over and over when initializing cache entities,
+    // now that IndexShardCacheEntity has to be non-static for serialization purposes
+    // (this was having significant performance impact)
+    protected static long indexShardCacheEntitySize = RamUsageEstimator.shallowSizeOfInstance(IndexShardCacheEntity.class);
+
     @Override
     protected void doStart() {
         // Start threads that will manage cleaning the field data and request caches periodically
@@ -1864,7 +1869,7 @@ public class IndicesService extends AbstractLifecycleComponent
      * @opensearch.internal
      */
     public final class IndexShardCacheEntity extends AbstractIndexShardCacheEntity {
-        private final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(IndexShardCacheEntity.class);
+        private final long BASE_RAM_BYTES_USED = IndicesService.indexShardCacheEntitySize;
         private final IndexShard indexShard;
 
         public IndexShardCacheEntity(IndexShard indexShard) {


### PR DESCRIPTION
### Description
Computes the estimated RAM size of IRC Key objects and IndicesService.IndexShardCacheEntity objects just once, rather than every time one gets instantiated. This was causing ~5% performance overhead in tiered caching relative to baseline. These classes were static before our tiered caching changes, so this should not cause any issues. 

### Related Issues
N/A

### Check List
- [N/A] New functionality includes testing.
  - [x] All tests pass
- [N/A] New functionality has been documented.
  - [N/A] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [N/A] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [N/A] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
